### PR TITLE
Fix link styling in assessment prep page

### DIFF
--- a/pages/AssessmentPrepComponent.js
+++ b/pages/AssessmentPrepComponent.js
@@ -28,7 +28,7 @@ export function AssessmentPrepComponent() {
                 <a href="#unit3-sac2-prep" class="button-style">Go to Unit 3 SAC 2 Prep</a>
                 <a
   href="/key-skills-hub"
-  className="mt-4 inline-block px-6 py-3 bg-purple-600 hover:bg-purple-700 text-white font-semibold rounded-xl shadow-md transition"
+  class="mt-4 inline-block px-6 py-3 bg-purple-600 hover:bg-purple-700 text-white font-semibold rounded-xl shadow-md transition"
 >
   🛠️ Go to Key Skills Hub
 </a>


### PR DESCRIPTION
## Summary
- correct anchor attribute in AssessmentPrepComponent

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build:css` *(fails: tailwindcss permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_6845580c0378832cbfc545f156abe019