### PR TITLE
Fix component imports

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,7 +10,7 @@ import { Unit3SAC2PrepComponent } from './components/Unit3SAC2PrepComponent.js';
 import { Unit3QuizComponent } from './pages/Unit3QuizComponent.js';
 import { Unit3FlashcardsComponent } from './pages/Unit3FlashcardsComponent.js';
 import { Unit3PracticeQuestionsComponent } from './pages/Unit3PracticeQuestionsComponent.js';
-import KeySkillsHub from "./components/KeySkillsHub";
+import KeySkillsHub from "./components/KeySkillsHub.js";
 import ReactDOM from 'react-dom/client';
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/components/KeySkillsHub.js
+++ b/components/KeySkillsHub.js
@@ -2,16 +2,16 @@
 import { useState } from 'react';
 import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
-import KeySkill1 from './KeySkill1';
-import KeySkill2 from './KeySkill2';
-import KeySkill3 from './KeySkill3';
-import KeySkill4 from './KeySkill4';
-import KeySkill5 from './KeySkill5';
-import KeySkill6 from './KeySkill6';
-import KeySkill7 from './KeySkill7';
-import KeySkill8 from './KeySkill8';
-import KeySkill9 from './KeySkill9';
-import KeySkill10 from './KeySkill10';
+import KeySkill1 from '../keyskillscomponets/KeySkill1.js';
+import KeySkill2 from '../keyskillscomponets/KeySkill2.js';
+import KeySkill3 from '../keyskillscomponets/KeySkill3.js';
+import KeySkill4 from '../keyskillscomponets/KeySkill4.js';
+import KeySkill5 from '../keyskillscomponets/KeySkill5.js';
+import KeySkill6 from '../keyskillscomponets/KeySkill6.js';
+import KeySkill7 from '../keyskillscomponets/KeySkill7.js';
+import KeySkill8 from '../keyskillscomponets/KeySkill8.js';
+import KeySkill9 from '../keyskillscomponets/KeySkill9.js';
+import KeySkill10 from '../keyskillscomponets/KeySkill10.js';
 
 export default function KeySkillsHubFull() {
   return (

--- a/keyskillscomponets/KeySkill4.js
+++ b/keyskillscomponets/KeySkill4.js
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import InitiativeDragDrop from './helpers/InitiativeDragDrop';
+import InitiativeDragDrop from './helpers/InitiativeDragDrop.js';
 
 const initiatives = [
   {

--- a/pages/key-skills-hub.js
+++ b/pages/key-skills-hub.js
@@ -1,4 +1,4 @@
-import KeySkillsHub from '../components/KeySkillsHub';
+import KeySkillsHub from '../components/KeySkillsHub.js';
 export default function KeySkillsHubPage() {
   return <KeySkillsHub />;
 }


### PR DESCRIPTION
## Summary
- fix ES module import extensions across Key Skills Hub components

## Testing
- `npm run build:css` *(fails: tailwindcss permission denied)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6846db0ad660832cadcaa85dd40f2ddc